### PR TITLE
Refactor tests to work with data providers

### DIFF
--- a/tests/EncodingTest.php
+++ b/tests/EncodingTest.php
@@ -7,23 +7,21 @@ use PHPUnit\Framework\TestCase;
 
 final class EncodingTest extends TestCase
 {
-    public function test_decodes_unnecessarily_encoded_characters(): void
+    /**
+     * @return Generator&iterable<string[]> [$expected, $path]
+     */
+    public function pathProvider(): Generator
     {
-        $this->assertEquals('/foo/bar', Encoding::decodePercentEncodedAsciiCharactersInPath('/f%6F%6f/b%61r'));
+        yield 'Unnecessarily encoded characters' => ['/foo/bar',       '/f%6F%6f/b%61r'];
+        yield 'Non ASCII characters'             => ['/f%F6%F6/b%E4r', '/f%F6%F6/b%E4r'];
+        yield 'Encoded reserved characters'      => ['%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D', '%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D'];
     }
 
-    public function test_not_decodes_non_ascii_characters(): void
+    /**
+     * @dataProvider pathProvider
+     */
+    public function test_decode(string $expected, string $path): void
     {
-        $this->assertEquals('/f%F6%F6/b%E4r', Encoding::decodePercentEncodedAsciiCharactersInPath('/f%F6%F6/b%E4r'));
-    }
-
-    public function test_not_decodes_encoded_reserved_characters(): void
-    {
-        $this->assertEquals(
-            '%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D',
-            Encoding::decodePercentEncodedAsciiCharactersInPath(
-                '%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D'
-            )
-        );
+        $this->assertEquals($expected, Encoding::decodePercentEncodedAsciiCharactersInPath($path));
     }
 }

--- a/tests/RulePatternTest.php
+++ b/tests/RulePatternTest.php
@@ -7,15 +7,30 @@ use PHPUnit\Framework\TestCase;
 
 final class RulePatternTest extends TestCase
 {
+    /**
+     * @return Generator&iterable<string[]> [$pattern, $uri]
+     */
+    public function validPatternProvider(): Generator
+    {
+        yield 'Exact match'                                   => ['/home',              '/home'];
+        yield 'Partial match'                                 => ['/jobs/controlling/', '/company/jobs/controlling/controller-f-m-x-2021-10-23'];
+        yield 'Single wildcard in pattern'                    => ['/foo/*/bar',         '/foo/yo/bar'];
+        yield 'Multiple wildcard in pattern'                  => ['/foo/*/bar*/baz',    '/foo/exa/mple/barbara/pew/pew/baz'];
+        yield 'URI that has percent encoded ASCII characters' => ['/foo/bar',           '/foo/b%61r'];
+    }
+
+    /**
+     * @dataProvider validPatternProvider
+     */
+    public function test_valid_patterns(string $pattern, string $uri): void
+    {
+        $this->assertTrue((new RulePattern($pattern))->matches($uri));
+    }
+
     public function test_it_returns_the_raw_pattern(): void
     {
         $pattern = new RulePattern('/fo%6F/*/baz$');
         $this->assertEquals('/fo%6F/*/baz$', $pattern->pattern());
-    }
-
-    public function test_match_an_exact_match(): void
-    {
-        $this->assertTrue((new RulePattern('/home'))->matches('/home'));
     }
 
     public function test_return_false_when_uri_does_not_match(): void
@@ -23,34 +38,10 @@ final class RulePatternTest extends TestCase
         $this->assertFalse((new RulePattern('/home'))->matches('/contact'));
     }
 
-    public function test_match_a_partial_match(): void
-    {
-        $pattern = new RulePattern('/jobs/controlling/');
-        $this->assertTrue($pattern->matches('/company/jobs/controlling/controller-f-m-x-2021-10-23'));
-    }
-
-    public function test_match_with_wildcard_in_pattern(): void
-    {
-        $pattern = new RulePattern('/foo/*/bar');
-        $this->assertTrue($pattern->matches('/foo/yo/bar'));
-    }
-
-    public function test_match_with_multiple_wildcards_in_pattern(): void
-    {
-        $pattern = new RulePattern('/foo/*/bar*/baz');
-        $this->assertTrue($pattern->matches('/foo/exa/mple/barbara/pew/pew/baz'));
-    }
-
     public function test_match_ends_with(): void
     {
         $pattern = new RulePattern('/foo/bar$');
         $this->assertTrue($pattern->matches('/foo/bar'));
         $this->assertFalse($pattern->matches('/foo/bar/baz'));
-    }
-
-    public function test_match_with_uri_that_has_percent_encoded_ascii_characters(): void
-    {
-        $pattern = new RulePattern('/foo/bar');
-        $this->assertTrue($pattern->matches('/foo/b%61r'));
     }
 }

--- a/tests/UserAgentGroupTest.php
+++ b/tests/UserAgentGroupTest.php
@@ -15,46 +15,77 @@ final class UserAgentGroupTest extends TestCase
         $this->userAgentGroup = new UserAgentGroup(['*']);
     }
 
+    /**
+     * @return Generator&iterable<array<string[]|string>> [$userAgents[], $contains]
+     */
+    public function containedUserAgentProvider(): Generator
+    {
+        yield 'Exact match'                => [['GoogleBot', 'FooBot', 'CrwlrBot',], 'FooBot'];
+        yield 'Case insensitive uppercase' => [['GoogleBot', 'FooBot', 'CrwlrBot',], 'foobot'];
+        yield 'Case insensitive lowercase' => [['GoogleBot', 'FooBot', 'CrwlrBot',], 'FOOBOT'];
+        yield 'Wildcard'                   => [['*',         'barbot',            ], 'foobot'];
+    }
+
+    /**
+     * @return Generator&iterable<string[],string,string> [$disallowedPatterns[], $allowedPattern, $uri]
+     */
+    public function allowedRulePatternProvider(): Generator
+    {
+        yield 'No matching rules'   => [['/admin', '/secret', ], '/secret/notsosecret', '/contact'];
+        yield 'Only matching rules' => [['/admin',            ], '/home',               'home'];
+        yield 'More specific URI'   => [['/secret',           ], '/secret/notsosecret', '/secret/notsosecret/something'];
+        yield 'Equivalent rules'    => [['/foo',              ], '/bar',                '/foo/bar'];
+    }
+
+    /**
+     * @return Generator&iterable<string[]> [$disallowedPatterns, $allowedPattern, $uri]
+     */
+    public function notAllowedRulePatternProvider(): Generator
+    {
+        yield 'Only matching dissallowed rule' => ['/admin',                      '/home',   '/admin'];
+        yield 'More specific rules'            => ['/secret/of-the-yaya-sisters', '/secret', '/secret/of-the-yaya-sisters'];
+    }
+
+    /**
+     * @dataProvider containedUserAgentProvider
+     *
+     * @param string[] $userAgents
+     */
+    public function test_contained_user_agent(array $userAgents, string $contains): void
+    {
+        $this->assertTrue((new UserAgentGroup($userAgents))->contains($contains));
+    }
+
+    /**
+     * @dataProvider allowedRulePatternProvider
+     *
+     * @param string[] $disallowedPatterns
+     */
+    public function test_is_allowed(array $disallowedPatterns, string $allowedPattern, string $uri): void
+    {
+        array_walk(
+            $disallowedPatterns,
+            fn (string $pattern) => $this->userAgentGroup->addDisallowedPattern(new RulePattern($pattern))
+        );
+        $this->userAgentGroup->addAllowedPattern(new RulePattern($allowedPattern));
+        $this->assertTrue($this->userAgentGroup->isAllowed($uri));
+    }
+
+    /**
+     * @dataProvider notAllowedRulePatternProvider
+     */
+    public function test_is_not_allowed(string $disallowedPatterns, string $allowedPattern, string $uri): void
+    {
+        $this->userAgentGroup->addDisallowedPattern(new RulePattern($disallowedPatterns));
+        $this->userAgentGroup->addAllowedPattern(new RulePattern($allowedPattern));
+        $this->assertFalse($this->userAgentGroup->isAllowed($uri));
+    }
+
     public function test_throws_exception_when_constructor_argument_array_contains_non_string_value(): void
     {
         $this->expectException(InvalidArgumentException::class);
         /* @phpstan-ignore-next-line  We're just testing that an Exception is thrown in that case */
         new UserAgentGroup(['foo', 'bar', 123]);
-    }
-
-    public function test_contains_returns_true_when_exact_user_agent_is_contained(): void
-    {
-        $userAgentGroup = new UserAgentGroup(['GoogleBot', 'FooBot', 'CrwlrBot']);
-        $this->assertTrue($userAgentGroup->contains('FooBot'));
-    }
-
-    public function test_contains_returns_false_when_user_agent_is_not_contained(): void
-    {
-        $userAgentGroup = new UserAgentGroup(['GoogleBot', 'FooBot', 'CrwlrBot']);
-        $this->assertFalse($userAgentGroup->contains('BarBot'));
-    }
-
-    public function test_contains_returns_true_when_user_agent_is_contained_case_insensitive(): void
-    {
-        $userAgentGroup = new UserAgentGroup(['GoogleBot', 'FooBot', 'CrwlrBot']);
-        $this->assertTrue($userAgentGroup->contains('foobot'));
-
-        $userAgentGroup = new UserAgentGroup(['GoogleBot', 'foobot', 'CrwlrBot']);
-        $this->assertTrue($userAgentGroup->contains('FOOBOT'));
-    }
-
-    public function test_contains_returns_true_when_wildcard_is_in_group(): void
-    {
-        $userAgentGroup = new UserAgentGroup(['*', 'barbot']);
-
-        $this->assertTrue($userAgentGroup->contains('foobot'));
-    }
-
-    public function test_contains_return_false_when_wildcard_is_in_group_but_arg_include_wildcard_is_set_to_false(): void
-    {
-        $userAgentGroup = new UserAgentGroup(['*', 'barbot']);
-
-        $this->assertFalse($userAgentGroup->contains('foobot', false));
     }
 
     public function test_adding_a_disallow_rule_pattern(): void
@@ -74,59 +105,5 @@ final class UserAgentGroupTest extends TestCase
     public function test_is_allowed_with_no_rule_at_all(): void
     {
         $this->assertTrue($this->userAgentGroup->isAllowed('/foo/bar'));
-    }
-
-    public function test_is_allowed_with_no_matching_rules(): void
-    {
-        $this->addDisallowedRulePattern('/admin');
-        $this->addDisallowedRulePattern('/secret');
-        $this->addAllowedRulePattern('/secret/notsosecret');
-        $this->assertTrue($this->userAgentGroup->isAllowed('/contact'));
-    }
-
-    public function test_is_allowed_with_only_matching_allowed_rule(): void
-    {
-        $this->addDisallowedRulePattern('/admin');
-        $this->addAllowedRulePattern('/home');
-        $this->assertTrue($this->userAgentGroup->isAllowed('home'));
-    }
-
-    public function test_is_not_allowed_with_only_matching_disallowed_rule(): void
-    {
-        $this->addDisallowedRulePattern('/admin');
-        $this->addAllowedRulePattern('/home');
-        $this->assertFalse($this->userAgentGroup->isAllowed('/admin'));
-    }
-
-    public function test_is_allowed_with_matching_allowed_and_disallowed_rules_and_allowed_is_more_specific(): void
-    {
-        $this->addDisallowedRulePattern('/secret');
-        $this->addAllowedRulePattern('/secret/notsosecret');
-        $this->assertTrue($this->userAgentGroup->isAllowed('/secret/notsosecret/something'));
-    }
-
-    public function test_is_not_allowed_with_matching_allowed_and_disallowed_rules_and_disallowed_is_more_specific(): void
-    {
-        $this->addDisallowedRulePattern('/secret/of-the-yaya-sisters');
-        $this->addAllowedRulePattern('/secret');
-        $this->assertFalse($this->userAgentGroup->isAllowed('/secret/of-the-yaya-sisters'));
-    }
-
-    public function test_is_allowed_with_matching_allowed_and_disallowed_rules_and_both_are_equivalent(): void
-    {
-        $this->addDisallowedRulePattern('/foo');
-        $this->addAllowedRulePattern('/bar');
-        $this->assertTrue($this->userAgentGroup->isAllowed('/foo/bar'));
-    }
-
-
-    private function addDisallowedRulePattern(string $pattern): void
-    {
-        $this->userAgentGroup->addDisallowedPattern(new RulePattern($pattern));
-    }
-
-    private function addAllowedRulePattern(string $pattern): void
-    {
-        $this->userAgentGroup->addAllowedPattern(new RulePattern($pattern));
     }
 }


### PR DESCRIPTION
With data providers, new test cases can be added without creating new test functions. What's being tested remains the same, but with less duplicated code.